### PR TITLE
perf: Speeds up CLI startup through lazy imports on Python 3.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,10 @@ repos:
         language: python
         additional_dependencies:
         - pyjson5==2.0.1
+
+  - repo: https://github.com/henryiii/flake8-lazy
+    rev: v0.8.2
+    hooks:
+      - id: flake8-lazy
+        args: ["--apply=set"]
+        files: '^tap_pypistats'

--- a/tap_pypistats/tap.py
+++ b/tap_pypistats/tap.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "datetime",
+    "json",
+    "pathlib",
+    "requests",
+    "requests.adapters",
+    "requests_cache",
+}
+
 import argparse
 import dataclasses
 import datetime


### PR DESCRIPTION
This was doing by following https://iscinumpy.dev/post/flake8-lazy/